### PR TITLE
Changes to keep support for Python 2.6

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -166,17 +166,17 @@ class SSHSession(Session):
         data = self._buffer.getvalue()
         data_len = len(data)
         start = 0
-        logger.debug('_parse11: working with buffer of {} bytes'.format(data_len))
+        logger.debug('_parse11: working with buffer of {0} bytes'.format(data_len))
         while True:
             # match to see if we found at least some kind of delimiter
-            logger.debug('_parse11: matching from {} bytes from start of buffer'.format(start))
+            logger.debug('_parse11: matching from {0} bytes from start of buffer'.format(start))
             re_result = RE_NC11_DELIM.match(data[start:].decode('utf-8'))
             if re_result:
                 
                 # save useful variables for reuse
                 re_start = re_result.start()
                 re_end = re_result.end()
-                logger.debug('_parse11: regular expression start={}, end={}'.format(re_start, re_end))
+                logger.debug('_parse11: regular expression start={0}, end={1}'.format(re_start, re_end))
                 
                 # If the regex doesn't start at the beginning of the buffer,
                 # we're in trouble, so throw an error
@@ -201,14 +201,14 @@ class SSHSession(Session):
                     # save the next chunk off
                     logger.debug('_parse11: found chunk delimiter')
                     digits = int(re_result.group(2))
-                    logger.debug('_parse11: chunk size {} bytes'.format(digits))
+                    logger.debug('_parse11: chunk size {0} bytes'.format(digits))
                     if (data_len-start) >= (re_end + digits):
                         # we have enough data for the chunk
                         fragment = textify(data[start+re_end:start+re_end+digits])
                         self._message_list.append(fragment)
                         start += re_end + digits
-                        logger.debug('_parse11: appending {} bytes'.format(digits))
-                        logger.debug('_parse11: fragment = "{}"'.format(fragment))
+                        logger.debug('_parse11: appending {0} bytes'.format(digits))
+                        logger.debug('_parse11: fragment = "{0}"'.format(fragment))
                     else:
                         # we don't have enough bytes, just break out for now
                         # after updating start pointer to start of new chunk
@@ -219,12 +219,12 @@ class SSHSession(Session):
                 # not found any kind of delimiter just break; this should only
                 # ever happen if we just have the first few characters of a
                 # message such that we don't yet have a full delimiter
-                logger.debug('_parse11: no delimiter found, buffer={}'.format(data[start:]))
+                logger.debug('_parse11: no delimiter found, buffer={0}'.format(data[start:]))
                 break
                 
         # Now out of the loop, need to see if we need to save back any content
         if start > 0:
-            logger.debug('_parse11: saving back rest of message after {} bytes, original size {}'.format(start, data_len))
+            logger.debug('_parse11: saving back rest of message after {0} bytes, original size {1}'.format(start, data_len))
             self._buffer = StringIO(data[start:])
         logger.debug('_parse11: ending')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools>0.6
-paramiko==2.4.0
+paramiko==2.3.0
 lxml>=3.3.0
 six
 python-dateutil>=2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools>0.6
-paramiko>=1.15.0
+paramiko==2.3.0
 lxml>=3.3.0
 six
 python-dateutil>=2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools>0.6
-paramiko==2.3.0
+paramiko==2.4.0
 lxml>=3.3.0
 six
 python-dateutil>=2.6.0


### PR DESCRIPTION
Paramiko needs to be kept at version 2.3.0, and a few format statements in parse11 needed to be made backwards compatible.