### PR TITLE
Fix memory leak for YANG subscriptions

### DIFF
--- a/ncclient/transport/session.py
+++ b/ncclient/transport/session.py
@@ -40,6 +40,20 @@ END_DELIM = b'\n##\n'
 TICK = 0.1
 
 
+def _is_yang_push_notification(raw):
+    """Check if a notification is a YANG Push notification."""
+    try:
+        root = to_ele(raw)
+
+        # Look for YANG Push notification types
+        push_update = root.find(qualify("push-update", IETF_YANG_PUSH_NS))
+        push_change_update = root.find(qualify("push-change-update",
+                                               IETF_YANG_PUSH_NS))
+        return push_update is not None or push_change_update is not None
+    except Exception:
+        return False
+
+
 class NetconfBase:
     '''Netconf Base protocol version'''
     BASE_10 = 1
@@ -109,7 +123,7 @@ class Session(Thread):
         def err_cb(err):
             error[0] = err
             init_event.set()
-        self.add_listener(NotificationHandler(self._notification_q))
+        self.add_listener(NotificationHandler(self._notification_q, self))
         listener = HelloHandler(ok_cb, err_cb)
         self.add_listener(listener)
         self.send(HelloHandler.build(self._client_capabilities, self._device_handler))
@@ -163,6 +177,18 @@ class Session(Thread):
             for listener in self._listeners:
                 if isinstance(listener, cls):
                     return listener
+
+    def has_yang_push_listener(self):
+        """
+        Check if session has a YANG Push listener registered.
+
+        :return: True if YANG Push listener is registered, False otherwise.
+        """
+        with self._lock:
+            for listener in self._listeners:
+                if hasattr(listener, 'subscription_listeners'):
+                    return True
+        return False
 
     def connect(self, *args, **kwds): # subclass implements
         raise NotImplementedError
@@ -366,12 +392,20 @@ class HelloHandler(SessionListener):
 
 
 class NotificationHandler(SessionListener):
-    def __init__(self, notification_q):
+    def __init__(self, notification_q, session=None):
         self._notification_q = notification_q
+        self._session = session
 
     def callback(self, root, raw):
         tag, _ = root
         if tag == qualify('notification', NETCONF_NOTIFICATION_NS):
+            # Check if this is a YANG Push notification and if we have
+            # a YANG Push listener, skipping queuing if so
+            if all([_is_yang_push_notification(raw),
+                    self._session,
+                    self._session.has_yang_push_listener()]):
+                return
+
             self._notification_q.put(Notification(raw))
 
     def errback(self, _):


### PR DESCRIPTION
This pull request enhances the handling of YANG Push notifications in the `ncclient` library, specifically ensuring that such notifications are only queued if no YANG Push listener is registered. It introduces logic to detect YANG Push notifications and provides new tests to verify this behavior, fixing issue #5 by addressing the problem cited [here](https://github.com/CiscoDevNet/ncclient/issues/5#issuecomment-435593993) without compromising RFC compliance.